### PR TITLE
docs:fix xxx tokens placeholder in context builder examples

### DIFF
--- a/src/en/chapter_context_engineering/04_practice_context_builder.md
+++ b/src/en/chapter_context_engineering/04_practice_context_builder.md
@@ -594,7 +594,7 @@ messages = pipeline.build(
 # 📥 Gather: collected 9 information fragments
 # 🔍 Select: filtered to 9 fragments
 # 📦 Summarize: compressed 0 overly long fragments
-# 🏗️ Construct: build complete, approximately XXX tokens
+# 🏗️ Construct: build complete, approximately 5000 tokens
 ```
 
 ## Section Summary

--- a/src/zh/chapter_context_engineering/04_practice_context_builder.md
+++ b/src/zh/chapter_context_engineering/04_practice_context_builder.md
@@ -594,7 +594,7 @@ messages = pipeline.build(
 # 📥 Gather: 收集了 9 个信息片段
 # 🔍 Select: 筛选出 9 个片段
 # 📦 Summarize: 压缩了 0 个超长片段
-# 🏗️ Construct: 构建完成，约 XXX tokens
+# 🏗️ Construct: 构建完成，约 5000 tokens
 ```
 
 ## 本节小结


### PR DESCRIPTION
Changes
- 修复 `src/zh/` 和 `src/en/` 的 `04_practice_context_builder.md` 第597行
- 将代码示例输出中的 `XXX tokens` 占位符替换为合理的 token 数值